### PR TITLE
Fix #7990 - Fix update_current_style not refreshing viewport

### DIFF
--- a/src/bonsai/bonsai/bim/module/style/operator.py
+++ b/src/bonsai/bonsai/bim/module/style/operator.py
@@ -239,13 +239,15 @@ class UpdateCurrentStyle(bpy.types.Operator):
             if not isinstance(obj.data, (bpy.types.Mesh, bpy.types.Curve)):
                 continue
             for mat in obj.data.materials:
-                if (
-                    mat
-                    and mat not in updated_materials
-                    and (msprops_ := tool.Style.get_material_style_props(mat)).ifc_definition_id != 0
-                ):
-                    msprops_.active_style_type = current_style_type
-                    updated_materials.add(mat)
+                if not mat:
+                    continue
+                msprops_ = tool.Style.get_material_style_props(mat)
+                if msprops_.ifc_definition_id == 0:
+                    continue
+                if mat in updated_materials:
+                    continue
+                msprops_.active_style_type = current_style_type
+                updated_materials.add(mat)
         return {"FINISHED"}
 
 

--- a/src/bonsai/bonsai/tool/style.py
+++ b/src/bonsai/bonsai/tool/style.py
@@ -976,12 +976,6 @@ class Style(bonsai.core.tool.Style):
     @classmethod
     def switch_shading(cls, blender_material: bpy.types.Material, style_type: StyleType) -> None:
         if style_type == "External":
-            ext, fast = cls.get_branch_outputs(blender_material)
-            if ext and fast:
-                ext.is_active_output = True
-                fast.is_active_output = False
-                blender_material.update_tag()
-                return
             try:
                 bpy.ops.bim.activate_external_style(material_name=blender_material.name)
             except RuntimeError as error:


### PR DESCRIPTION
Switching to External style had no visible effect because switch_shading used a fast-path that only flipped
is_active_output on the dual-branch nodes. This was a no-op when BIM_Output_External was already active, and material.update_tag() alone was insufficient to trigger a viewport redraw regardless. Fix by always calling activate_external_style for the External case, which re-loads the .blend material and goes through Blender's operator path that reliably refreshes the viewport.

Generated with the assistance of an AI coding tool. AI effort: 4/10